### PR TITLE
Fix podfile in sample project

### DIFF
--- a/VENCalculatorInputViewSample/Podfile
+++ b/VENCalculatorInputViewSample/Podfile
@@ -2,5 +2,5 @@ platform :ios, '5.0'
 inhibit_all_warnings!
 
 target 'VENCalculatorInputViewSample', :exclusive => true do
-  pod 'VENCalculatorInputView', :path => '../VENCalculatorInputView.podspec'
+  pod 'VENCalculatorInputView', :path => './../VENCalculatorInputView.podspec'
 end

--- a/VENCalculatorInputViewSample/Podfile.lock
+++ b/VENCalculatorInputViewSample/Podfile.lock
@@ -1,14 +1,14 @@
 PODS:
-  - VENCalculatorInputView (1.0.0)
+  - VENCalculatorInputView (1.1.0)
 
 DEPENDENCIES:
-  - VENCalculatorInputView (from `../VENCalculatorInputView.podspec`)
+  - VENCalculatorInputView (from `./../VENCalculatorInputView.podspec`)
 
 EXTERNAL SOURCES:
   VENCalculatorInputView:
-    :path: ../VENCalculatorInputView.podspec
+    :path: ./../VENCalculatorInputView.podspec
 
 SPEC CHECKSUMS:
-  VENCalculatorInputView: d833dfd46ef7597a6f250f5e14a31c560b6884e4
+  VENCalculatorInputView: ed89b1b2adc0f2394143353f17ba0cd4456a5ab3
 
 COCOAPODS: 0.29.0


### PR DESCRIPTION
I was getting this:

```
[!] Unable to satisfy the following requirements:
- `VENCalculatorInputView (from `../VENCalculatorInputView.podspec`)` required by `Podfile`
```

when `pod install`ing the sample project. I changed the path to `./..`, not sure why `../` doesn't work.
