### PR TITLE
Sample App Portrait Only

### DIFF
--- a/VENCalculatorInputViewSample/VENCalculatorInputViewSample/VENCalculatorInputViewSample-Info.plist
+++ b/VENCalculatorInputViewSample/VENCalculatorInputViewSample/VENCalculatorInputViewSample-Info.plist
@@ -33,8 +33,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Since VENCalculatorInputView currently supports portrait orientation only, the sample app should not support landscape orientations. :octopus: 
