### PR TITLE
Fix handling Deutsch.

### DIFF
--- a/VENCalculatorInputView/VENMoneyCalculator.m
+++ b/VENCalculatorInputView/VENMoneyCalculator.m
@@ -19,12 +19,12 @@
     if (!expressionString) {
         return nil;
     }
-    NSString *floatString = [NSString stringWithFormat:@"1.0*%@", expressionString];
-    NSString *sanitizedString = [self sanitizedString:floatString];
+    NSString *sanitizedString = [self sanitizedString:expressionString];
+    NSString *floatString = [NSString stringWithFormat:@"1.0*%@", sanitizedString];
     NSExpression *expression;
     id result;
     @try {
-        expression = [NSExpression expressionWithFormat:sanitizedString];
+        expression = [NSExpression expressionWithFormat:floatString];
         result = [expression expressionValueWithObject:nil context:nil];
     }
     @catch (NSException *exception) {
@@ -56,15 +56,17 @@
 - (NSNumberFormatter *)numberFormatter {
     if (!_numberFormatter) {
         _numberFormatter = [NSNumberFormatter new];
+        [_numberFormatter setLocale:self.locale];
         [_numberFormatter setNumberStyle:NSNumberFormatterCurrencyStyle];
         [_numberFormatter setCurrencySymbol:@""];
-        [_numberFormatter setCurrencyDecimalSeparator:[self decimalSeparator]];
     }
     return _numberFormatter;
 }
 
 - (NSString *)sanitizedString:(NSString *)string {
-    return [[self replaceOperandsInString:string] stringByReplacingCharactersInSet:[self illegalCharacters] withString:@""];
+    NSString *groupingSeperator = [self.locale objectForKey:NSLocaleGroupingSeparator];
+    NSString *withoutGroupingSeperator = [string stringByReplacingOccurrencesOfString:groupingSeperator withString:@""];
+    return [[self replaceOperandsInString:withoutGroupingSeperator] stringByReplacingCharactersInSet:[self illegalCharacters] withString:@""];
 }
 
 - (NSString *)replaceOperandsInString:(NSString *)string {

--- a/VENCalculatorInputViewTests/VENMoneyCalculatorSpec.m
+++ b/VENCalculatorInputViewTests/VENMoneyCalculatorSpec.m
@@ -94,4 +94,30 @@ describe(@"Handle other locale", ^{
 
 });
 
+describe(@"Handle Deutsch, which use . as grouping seperator", ^{
+    __block VENMoneyCalculator *moneyCalculator;
+
+    beforeAll(^{
+        moneyCalculator = [VENMoneyCalculator new];
+        moneyCalculator.locale = [NSLocale localeWithLocaleIdentifier:@"de_DE"];
+    });
+
+    it(@"should handle division", ^{
+        expect([moneyCalculator evaluateExpression:@"2/2"]).to.equal(@"1");
+        expect([moneyCalculator evaluateExpression:@"100/4"]).to.equal(@"25");
+        expect([moneyCalculator evaluateExpression:@"1/2"]).to.equal(@"0,50");
+    });
+
+    it(@"should handle ×", ^{
+        expect([moneyCalculator evaluateExpression:@"100×1,2"]).to.equal(@"120");
+        expect([moneyCalculator evaluateExpression:@"1000 × 0,8"]).to.equal(@"800");
+    });
+
+    it(@"should handle big numbers", ^{
+        expect([moneyCalculator evaluateExpression:@"1.035,01+40"]).to.equal(@"1.075,01");
+        expect([moneyCalculator evaluateExpression:@"1.040,01-1.035"]).to.equal(@"5,01");
+    });
+
+});
+
 SpecEnd


### PR DESCRIPTION
Deutsch use `.` as grouping seperator and `,` as decimal seperator, so this commit basically fixing some bug around grouping seperator handling.

You tested French, but they use ` ` (white space) as grouping seperator, and because of 
```
- (NSCharacterSet *)illegalCharacters {
    return [[NSCharacterSet characterSetWithCharactersInString:@"0123456789-/*.+"] invertedSet];
}
```
you silently converted ` ` to empty but this won't cover all case.