### PR TITLE
Updated sample project podfile to match podspec deployment target

### DIFF
--- a/VENCalculatorInputViewSample/Podfile
+++ b/VENCalculatorInputViewSample/Podfile
@@ -1,4 +1,4 @@
-platform :ios, '5.0'
+platform :ios, '6.0'
 inhibit_all_warnings!
 
 target 'VENCalculatorInputViewSample', :exclusive => true do


### PR DESCRIPTION
`pod install` was failing because the sample project specified 5.0 and the podspec had been updated to 6.0.
