### PR TITLE
Fix bug when user first press the `decimalSeparator`

### DIFF
--- a/VENCalculatorInputView/VENCalculatorInputTextField.m
+++ b/VENCalculatorInputView/VENCalculatorInputTextField.m
@@ -80,6 +80,9 @@
             self.text = subString;
         }
     } else if ([key isEqualToString:[self decimalSeparator]]) {
+        if (self.text.length == 1) {
+          self.text = [NSString stringWithFormat:@"0%@",[self decimalSeparator]];
+        }
         NSString *secondToLastCharacterString = [self.text substringWithRange:NSMakeRange([self.text length] - 2, 1)];
         if ([secondToLastCharacterString isEqualToString:[self decimalSeparator]]) {
             self.text = subString;


### PR DESCRIPTION
When user press the `decimalSeparator` as the first character of the `InputTextField` the app crash because a index out of bounds on `-[__NSCFString substringWithRange:]:` line 83.

Waiting for review @ayanonagon :)
