### PR TITLE
Compatibility with number greater than 8 digits

### DIFF
--- a/VENCalculatorInputView/VENMoneyCalculator.m
+++ b/VENCalculatorInputView/VENMoneyCalculator.m
@@ -36,7 +36,7 @@
     }
     if ([result isKindOfClass:[NSNumber class]]) {
         NSInteger integerExpression = [(NSNumber *)result integerValue];
-        CGFloat floatExpression = [(NSNumber *)result floatValue];
+        CGFloat floatExpression = [(NSNumber *)result doubleValue];
         if (integerExpression == floatExpression) {
             return [(NSNumber *)result stringValue];
         } else if (floatExpression >= CGFLOAT_MAX || floatExpression <= CGFLOAT_MIN || isnan(floatExpression)) {

--- a/VENCalculatorInputViewTests/VENMoneyCalculatorSpec.m
+++ b/VENCalculatorInputViewTests/VENMoneyCalculatorSpec.m
@@ -70,6 +70,15 @@ describe(@"Evaluate expressions", ^{
         expect([moneyCalculator evaluateExpression:@"-2÷0"]).to.equal(@"0");
         expect([moneyCalculator evaluateExpression:@"-0÷0"]).to.equal(@"0");
     });
+    
+    it(@"should handle long number", ^{
+        expect([moneyCalculator evaluateExpression:@"123456*2"]).to.equal(@"246912");
+        expect([moneyCalculator evaluateExpression:@"1234567*2"]).to.equal(@"2469134");
+        expect([moneyCalculator evaluateExpression:@"12345678*2"]).to.equal(@"24691356");
+        expect([moneyCalculator evaluateExpression:@"123456789*2"]).to.equal(@"246913578");
+        expect([moneyCalculator evaluateExpression:@"1234567890*2"]).to.equal(@"2469135780");
+        expect([moneyCalculator evaluateExpression:@"123456789*100"]).to.equal(@"12345678900");
+    });
 
 });
 


### PR DESCRIPTION
When an user enters a number greater than 8 digits with an operation, the result is wrong:
123456789*100 => 12345678848 (expected result: 12345678900).

I fix the problem by replacing the conversion of the `NSNumber result` from a float to a double in the `evaluateExpression` function of `VENMoneyCalculator.m`.
I also add test to verify that long number are handle correctly by the function.
