### PR TITLE
Fix user can type multiple decimal separator issue for issue #34

### DIFF
--- a/VENCalculatorInputView/VENCalculatorInputTextField.m
+++ b/VENCalculatorInputView/VENCalculatorInputTextField.m
@@ -84,6 +84,17 @@
         if ([secondToLastCharacterString isEqualToString:[self decimalSeparator]]) {
             self.text = subString;
         }
+        if([subString rangeOfString:@"+"].location != NSNotFound ||
+           [subString rangeOfString:@"−"].location != NSNotFound ||
+           [subString rangeOfString:@"×"].location != NSNotFound ||
+           [subString rangeOfString:@"÷"].location != NSNotFound
+           ){
+            if([[subString componentsSeparatedByString:[self decimalSeparator]] count] > 2){
+             self.text = subString;
+            }
+        }else if ([subString rangeOfString:[self decimalSeparator]].location != NSNotFound){
+            self.text = subString;
+        }
     }
 }
 


### PR DESCRIPTION
Fix user can type multiple decimal separator issue, now user can not type number like '123.123.123' or '123.123 × 123.32.32'
