### PR TITLE
Clear evaluated text when the only remaining character is the prefix

### DIFF
--- a/CalculatorInput/CalculatorInputTextField.h
+++ b/CalculatorInput/CalculatorInputTextField.h
@@ -2,6 +2,8 @@
 
 #import "CalculatorInputView.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CalculatorInputTextField : UITextField <CalculatorInputViewDelegate>
 
 /**
@@ -33,3 +35,5 @@
 -(NSString *)currentEvaluatedStringWithChangedCharactersInRange:(NSRange)range replacementString:(NSString *)replacementString;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/CalculatorInput/CalculatorInputTextField.m
+++ b/CalculatorInput/CalculatorInputTextField.m
@@ -54,7 +54,7 @@
 
 - (NSString *)currentEvaluatedString {
     if(self.text.length == 0){
-        return self.text;
+        return @"";
     }else{
         return [self evaluateString:self.text];
     }
@@ -112,6 +112,10 @@
 
 - (void)calculatorInputViewDidTapBackspace:(CalculatorInputView *)calculatorInputView {
     [self deleteBackward];
+
+    if ([self.text isEqualToString:self.prefix]) {
+        [self deleteBackward];
+    }
 }
 
 

--- a/CalculatorInput/NSString+CalculatorInputView.h
+++ b/CalculatorInput/NSString+CalculatorInputView.h
@@ -1,8 +1,12 @@
 @import Foundation;
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface NSString (CalculatorInputView)
 
 - (NSString *)ven_stringByReplacingCharactersInSet:(NSCharacterSet *)characterSet
                                     withString:(NSString *)string;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Supports IOS-1103

* Audits CalculatorInputTextField for nullability
* Adds an extra call to `deleteBackwards` if the only remaining text is the prefix character.