### PR TITLE
Make rounding behavior consistent

### DIFF
--- a/CalculatorInput.xcodeproj/project.pbxproj
+++ b/CalculatorInput.xcodeproj/project.pbxproj
@@ -208,14 +208,16 @@
 		367628501B420FF80081488E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = Venmo;
 				TargetAttributes = {
 					367628581B420FF80081488E = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0830;
 					};
 					367628621B420FF80081488E = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -304,8 +306,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -351,8 +355,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -372,6 +378,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -383,6 +390,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -393,6 +401,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInput;
 				PRODUCT_NAME = CalculatorInput;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -400,6 +409,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -410,6 +420,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInput;
 				PRODUCT_NAME = CalculatorInput;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -420,6 +431,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInputViewTests;
 				PRODUCT_NAME = CalculatorInput;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -430,6 +443,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInputViewTests;
 				PRODUCT_NAME = CalculatorInput;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/CalculatorInput.xcodeproj/project.pbxproj
+++ b/CalculatorInput.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 		361C4E931B421E7B00AB5D98 /* UITextField+CalculatorInputView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITextField+CalculatorInputView.h"; sourceTree = "<group>"; };
 		361C4E941B421E7B00AB5D98 /* UITextField+CalculatorInputView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITextField+CalculatorInputView.m"; sourceTree = "<group>"; };
 		367628591B420FF80081488E /* CalculatorInput.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CalculatorInput.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		367628631B420FF80081488E /* CalculatorInput.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorInput.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		367628631B420FF80081488E /* CalculatorInputTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorInputTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		367628851B4210520081488E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		367628861B4210520081488E /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		367628881B4210520081488E /* MoneyCalculatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoneyCalculatorTests.swift; sourceTree = "<group>"; };
@@ -132,7 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				367628591B420FF80081488E /* CalculatorInput.framework */,
-				367628631B420FF80081488E /* CalculatorInput.xctest */,
+				367628631B420FF80081488E /* CalculatorInputTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -199,7 +199,7 @@
 			);
 			name = CalculatorInputTests;
 			productName = CalculatorInputViewTests;
-			productReference = 367628631B420FF80081488E /* CalculatorInput.xctest */;
+			productReference = 367628631B420FF80081488E /* CalculatorInputTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -430,7 +430,7 @@
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInputViewTests;
-				PRODUCT_NAME = CalculatorInput;
+				PRODUCT_NAME = CalculatorInputTests;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 3.0;
 			};
@@ -442,7 +442,7 @@
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInputViewTests;
-				PRODUCT_NAME = CalculatorInput;
+				PRODUCT_NAME = CalculatorInputTests;
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;

--- a/CalculatorInput.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/CalculatorInput.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/CalculatorInput.xcodeproj/xcshareddata/xcschemes/CalculatorInput-iOS.xcscheme
+++ b/CalculatorInput.xcodeproj/xcshareddata/xcschemes/CalculatorInput-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -52,11 +52,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -74,10 +74,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/CalculatorInput.xcodeproj/xcshareddata/xcschemes/CalculatorInput-iOS.xcscheme
+++ b/CalculatorInput.xcodeproj/xcshareddata/xcschemes/CalculatorInput-iOS.xcscheme
@@ -33,7 +33,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "367628621B420FF80081488E"
-               BuildableName = "CalculatorInput.xctest"
+               BuildableName = "CalculatorInputTests.xctest"
                BlueprintName = "CalculatorInputTests"
                ReferencedContainer = "container:CalculatorInput.xcodeproj">
             </BuildableReference>

--- a/CalculatorInput/CalculatorInputTextField.m
+++ b/CalculatorInput/CalculatorInputTextField.m
@@ -17,6 +17,7 @@
 }
 
 - (void)awakeFromNib {
+    [super awakeFromNib];
     [self setUpInit];
 }
 

--- a/CalculatorInput/CalculatorInputView.m
+++ b/CalculatorInput/CalculatorInputView.m
@@ -11,6 +11,7 @@
 @implementation CalculatorInputView
 
 - (id)initWithFrame:(CGRect)frame {
+    self = [super initWithFrame:frame];
     self = [[[NSBundle bundleForClass:[self class]] loadNibNamed:@"CalculatorInputView" owner:self options:nil] firstObject];
     if (self) {
         // Set default locale

--- a/CalculatorInput/MoneyCalculator.m
+++ b/CalculatorInput/MoneyCalculator.m
@@ -40,21 +40,17 @@
             [exception raise];
         }
     }
-    if ([result isKindOfClass:[NSNumber class]]) {
-        NSInteger integerExpression = [(NSNumber *)result integerValue];
-        CGFloat floatExpression = [(NSNumber *)result floatValue];
-        if (!allowNegativeResult && floatExpression < 0) {
-            return @"0";
-        } else if (integerExpression == floatExpression) {
-            return [(NSNumber *)result stringValue];
-        } else if (floatExpression >= CGFLOAT_MAX || floatExpression <= CGFLOAT_MIN || isnan(floatExpression)) {
-            return @"0";
-        } else {
-            NSString *moneyFormattedNumber = [[self numberFormatter] stringFromNumber:@(floatExpression)];
-            return [moneyFormattedNumber stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
-        }
-    } else {
+    if (![result isKindOfClass:[NSNumber class]]) {
         return nil;
+    }
+    
+    NSNumber *number = (NSNumber *)result;
+    NSDecimalNumber *decimalNumber = [[NSDecimalNumber alloc] initWithDecimal:number.decimalValue];
+    
+    if ([self decimalNumberIsValid:decimalNumber allowNegativeValues:allowNegativeResult]) {
+        return [self formattedDecimalNumber:decimalNumber];
+    } else {
+        return [self formattedDecimalNumber:[NSDecimalNumber zero]];
     }
 }
 
@@ -88,6 +84,28 @@
     NSString *multiplyReplaced = [divideReplaced stringByReplacingOccurrencesOfString:@"×" withString:@"*"];
 
     return [multiplyReplaced stringByReplacingOccurrencesOfString:[self decimalSeparator] withString:@"."];
+}
+
+- (NSString *)formattedDecimalNumber:(NSDecimalNumber *)decimalNumber {
+    NSCharacterSet *set = [NSCharacterSet whitespaceAndNewlineCharacterSet];
+    return [[[self numberFormatter] stringFromNumber:decimalNumber] stringByTrimmingCharactersInSet:set];
+}
+
+- (BOOL)decimalNumberIsValid:(NSDecimalNumber *)decimalNumber allowNegativeValues:(BOOL)allowNegativeValues {
+    if ([decimalNumber isEqual:[NSDecimalNumber notANumber]]) {
+        return NO;
+    }
+
+    if ([decimalNumber compare:[NSDecimalNumber zero]] == NSOrderedAscending && !allowNegativeValues) {
+        return NO;
+    }
+
+    if ([decimalNumber compare:[NSDecimalNumber minimumDecimalNumber]] == NSOrderedAscending
+        || [decimalNumber compare:[NSDecimalNumber maximumDecimalNumber]] == NSOrderedDescending) {
+        return NO;
+    }
+
+    return YES;
 }
 
 - (NSCharacterSet *)illegalCharacters {

--- a/Tests/MoneyCalculatorTests.swift
+++ b/Tests/MoneyCalculatorTests.swift
@@ -5,7 +5,7 @@ import CalculatorInput
 class MoneyCalculatorTests: XCTestCase {
     let calculator: MoneyCalculator = {
         let calc = MoneyCalculator()
-        calc.locale = NSLocale(localeIdentifier: "en_US")
+        calc.locale = Locale(identifier: "en_US")
         return calc
     }()
 
@@ -70,7 +70,7 @@ class MoneyCalculatorTests: XCTestCase {
 class MoneyCalculatorFrenchTests: XCTestCase {
     let calculator: MoneyCalculator = {
         let calc = MoneyCalculator()
-        calc.locale = NSLocale(localeIdentifier: "fr_FR")
+        calc.locale = Locale(identifier: "fr_FR")
         return calc
     }()
 
@@ -88,7 +88,7 @@ class MoneyCalculatorFrenchTests: XCTestCase {
 class MoneyCalculatorGermanTests: XCTestCase {
     let calculator: MoneyCalculator = {
         let calc = MoneyCalculator()
-        calc.locale = NSLocale(localeIdentifier: "de_DE")
+        calc.locale = Locale(identifier: "de_DE")
         return calc
     }()
 
@@ -111,15 +111,15 @@ class MoneyCalculatorGermanTests: XCTestCase {
 class MoneyCalculatorVietnameTests: XCTestCase {
     func testVietnamese() {
         let calculator = MoneyCalculator()
-        calculator.locale = NSLocale(localeIdentifier: "vi_VN")
         XCTAssertEqual("2", calculator.evaluateExpression("1,90")!)
         XCTAssertEqual("1", calculator.evaluateExpression("1,30")!)
         XCTAssertEqual("1", calculator.evaluateExpression("0,90")!)
+        calculator.locale = Locale(identifier: "vi_VN")
     }
 
     func testUS() {
         let calculator = MoneyCalculator()
-        calculator.locale = NSLocale(localeIdentifier: "en_US")
+        calculator.locale = Locale(identifier: "en_US")
         XCTAssertEqual("1.90", calculator.evaluateExpression("1.90")!)
         XCTAssertEqual("1.30", calculator.evaluateExpression("1.30")!)
         XCTAssertEqual("0.90", calculator.evaluateExpression("0.90")!)

--- a/Tests/MoneyCalculatorTests.swift
+++ b/Tests/MoneyCalculatorTests.swift
@@ -10,39 +10,39 @@ class MoneyCalculatorTests: XCTestCase {
     }()
 
     func testAddition() {
-        XCTAssertEqual("2", calculator.evaluateExpression("1+1")!)
-        XCTAssertEqual("2", calculator.evaluateExpression("1 + 1")!)
-        XCTAssertEqual("1001", calculator.evaluateExpression("1 + 1000")!)
+        XCTAssertEqual("2.00", calculator.evaluateExpression("1+1")!)
+        XCTAssertEqual("2.00", calculator.evaluateExpression("1 + 1")!)
+        XCTAssertEqual("1,001.00", calculator.evaluateExpression("1 + 1000")!)
     }
 
     func testSubtraction() {
-        XCTAssertEqual("0", calculator.evaluateExpression("1-1")!)
-        XCTAssertEqual("9999", calculator.evaluateExpression("10000-1")!)
-        XCTAssertEqual("-100", calculator.evaluateExpression("0 - 100")!)
+        XCTAssertEqual("0.00", calculator.evaluateExpression("1-1")!)
+        XCTAssertEqual("9,999.00", calculator.evaluateExpression("10000-1")!)
+        XCTAssertEqual("-100.00", calculator.evaluateExpression("0 - 100")!)
 
         // Longer dash
-        XCTAssertEqual("0", calculator.evaluateExpression("1−1")!)
-        XCTAssertEqual("9999", calculator.evaluateExpression("10000−1")!)
-        XCTAssertEqual("-100", calculator.evaluateExpression("0 − 100")!)
+        XCTAssertEqual("0.00", calculator.evaluateExpression("1−1")!)
+        XCTAssertEqual("9,999.00", calculator.evaluateExpression("10000−1")!)
+        XCTAssertEqual("-100.00", calculator.evaluateExpression("0 − 100")!)
     }
 
     func testMultiplication() {
-        XCTAssertEqual("4", calculator.evaluateExpression("2*2")!)
-        XCTAssertEqual("120", calculator.evaluateExpression("100*1.2")!)
-        XCTAssertEqual("800", calculator.evaluateExpression("1000 * 0.8")!)
+        XCTAssertEqual("4.00", calculator.evaluateExpression("2*2")!)
+        XCTAssertEqual("120.00", calculator.evaluateExpression("100*1.2")!)
+        XCTAssertEqual("800.00", calculator.evaluateExpression("1000 * 0.8")!)
 
-        XCTAssertEqual("4", calculator.evaluateExpression("2×2")!)
-        XCTAssertEqual("120", calculator.evaluateExpression("100×1.2")!)
-        XCTAssertEqual("800", calculator.evaluateExpression("1000 × 0.8")!)
+        XCTAssertEqual("4.00", calculator.evaluateExpression("2×2")!)
+        XCTAssertEqual("120.00", calculator.evaluateExpression("100×1.2")!)
+        XCTAssertEqual("800.00", calculator.evaluateExpression("1000 × 0.8")!)
     }
 
     func testDivision() {
-        XCTAssertEqual("1", calculator.evaluateExpression("2/2")!)
-        XCTAssertEqual("25", calculator.evaluateExpression("100/4")!)
+        XCTAssertEqual("1.00", calculator.evaluateExpression("2/2")!)
+        XCTAssertEqual("25.00", calculator.evaluateExpression("100/4")!)
         XCTAssertEqual("0.50", calculator.evaluateExpression("1/2")!)
 
-        XCTAssertEqual("1", calculator.evaluateExpression("2÷2")!)
-        XCTAssertEqual("25", calculator.evaluateExpression("100÷4")!)
+        XCTAssertEqual("1.00", calculator.evaluateExpression("2÷2")!)
+        XCTAssertEqual("25.00", calculator.evaluateExpression("100÷4")!)
         XCTAssertEqual("0.50", calculator.evaluateExpression("1÷2")!)
     }
 
@@ -54,15 +54,15 @@ class MoneyCalculatorTests: XCTestCase {
     }
 
     func testDivisionByZero() {
-        XCTAssertEqual("0", calculator.evaluateExpression("2÷0")!)
-        XCTAssertEqual("0", calculator.evaluateExpression("0÷0")!)
-        XCTAssertEqual("0", calculator.evaluateExpression("-2÷0")!)
-        XCTAssertEqual("0", calculator.evaluateExpression("-0÷0")!)
+        XCTAssertEqual("0.00", calculator.evaluateExpression("2÷0")!)
+        XCTAssertEqual("0.00", calculator.evaluateExpression("0÷0")!)
+        XCTAssertEqual("0.00", calculator.evaluateExpression("-2÷0")!)
+        XCTAssertEqual("0.00", calculator.evaluateExpression("-0÷0")!)
     }
 
     func testAllowNegativeNumbers() {
-        XCTAssertEqual("1", calculator.evaluateExpression("2-1")!)
-        XCTAssertEqual("0", calculator.evaluateExpression("0-100", allowNegativeResult: false)!)
+        XCTAssertEqual("1.00", calculator.evaluateExpression("2-1")!)
+        XCTAssertEqual("0.00", calculator.evaluateExpression("0-100", allowNegativeResult: false)!)
     }
 
     func testDecimalRounding() {
@@ -80,8 +80,8 @@ class MoneyCalculatorFrenchTests: XCTestCase {
     }()
 
     func testMultiplication() {
-        XCTAssertEqual("120", calculator.evaluateExpression("100*1,2")!)
-        XCTAssertEqual("800", calculator.evaluateExpression("1000 * 0,8")!)
+        XCTAssertEqual("120,00", calculator.evaluateExpression("100*1,2")!)
+        XCTAssertEqual("800,00", calculator.evaluateExpression("1000 * 0,8")!)
     }
 
     func testDivision() {
@@ -98,8 +98,8 @@ class MoneyCalculatorGermanTests: XCTestCase {
     }()
 
     func testMultiplication() {
-        XCTAssertEqual("120", calculator.evaluateExpression("100*1,2")!)
-        XCTAssertEqual("800", calculator.evaluateExpression("1000 * 0,8")!)
+        XCTAssertEqual("120,00", calculator.evaluateExpression("100*1,2")!)
+        XCTAssertEqual("800,00", calculator.evaluateExpression("1000 * 0,8")!)
     }
 
     func testDivision() {
@@ -116,10 +116,11 @@ class MoneyCalculatorGermanTests: XCTestCase {
 class MoneyCalculatorVietnameTests: XCTestCase {
     func testVietnamese() {
         let calculator = MoneyCalculator()
+        calculator.locale = Locale(identifier: "vi_VN")
         XCTAssertEqual("2", calculator.evaluateExpression("1,90")!)
         XCTAssertEqual("1", calculator.evaluateExpression("1,30")!)
         XCTAssertEqual("1", calculator.evaluateExpression("0,90")!)
-        calculator.locale = Locale(identifier: "vi_VN")
+        XCTAssertEqual("1.000", calculator.evaluateExpression("100+900")!)
     }
 
     func testUS() {

--- a/Tests/MoneyCalculatorTests.swift
+++ b/Tests/MoneyCalculatorTests.swift
@@ -64,6 +64,11 @@ class MoneyCalculatorTests: XCTestCase {
         XCTAssertEqual("1", calculator.evaluateExpression("2-1")!)
         XCTAssertEqual("0", calculator.evaluateExpression("0-100", allowNegativeResult: false)!)
     }
+
+    func testDecimalRounding() {
+        XCTAssertEqual("1.44", calculator.evaluateExpression("1.445"))
+        XCTAssertEqual("2.44", calculator.evaluateExpression("2.445"))
+    }
 }
 
 

--- a/Tests/StringExtensionTests.swift
+++ b/Tests/StringExtensionTests.swift
@@ -4,13 +4,13 @@ import CalculatorInput
 
 class StringExtensionTests: XCTestCase {
     func testWhitespace() {
-        let result = NSString(string: "foo     bar\n           ").ven_stringByReplacingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet(), withString: "")
+        let result = NSString(string: "foo     bar\n           ").ven_stringByReplacingCharacters(in: CharacterSet.whitespacesAndNewlines, with: "")
         XCTAssertEqual("foobar", result)
     }
 
     func testCustomCharacterSet() {
-        let characterSet = NSCharacterSet(charactersInString: "0123456789-/*.+").invertedSet
-        let result = NSString(string: "1+1(&^!@#+1foobar").ven_stringByReplacingCharactersInSet(characterSet, withString: "")
+        let characterSet = CharacterSet(charactersIn: "0123456789-/*.+").inverted
+        let result = NSString(string: "1+1(&^!@#+1foobar").ven_stringByReplacingCharacters(in: characterSet, with: "")
         XCTAssertEqual("1+1+1", result)
     }
 }

--- a/VENCalculatorInputView.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/VENCalculatorInputView.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+</Workspace>


### PR DESCRIPTION
* Refactors `MoneyCalculator` to use `NSDecimalNumber`s to avoid floating point rounding errors. For example, $1.445 and $2.445 would previously format as $1.44 and $2.45 respectively. Formatted amounts now also consistently use the default grouping separator given the locale. Tests have been updated accordingly.
* Migrates the test suite to Swift 3 and allows Xcode to update project settings and schemes.
* Fixes two minor warnings.