### PR TITLE
Refresh the look and feel of the number pad

### DIFF
--- a/CalculatorInput.xcodeproj/project.pbxproj
+++ b/CalculatorInput.xcodeproj/project.pbxproj
@@ -389,6 +389,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/CalculatorInput/Resources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInput;
 				PRODUCT_NAME = CalculatorInput;
@@ -406,6 +407,7 @@
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				INFOPLIST_FILE = "$(SRCROOT)/CalculatorInput/Resources/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInput;
 				PRODUCT_NAME = CalculatorInput;

--- a/CalculatorInput.xcodeproj/project.pbxproj
+++ b/CalculatorInput.xcodeproj/project.pbxproj
@@ -55,7 +55,7 @@
 		361C4E931B421E7B00AB5D98 /* UITextField+CalculatorInputView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UITextField+CalculatorInputView.h"; sourceTree = "<group>"; };
 		361C4E941B421E7B00AB5D98 /* UITextField+CalculatorInputView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UITextField+CalculatorInputView.m"; sourceTree = "<group>"; };
 		367628591B420FF80081488E /* CalculatorInput.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = CalculatorInput.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		367628631B420FF80081488E /* CalculatorInput.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorInput.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		367628631B420FF80081488E /* CalculatorInputTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = CalculatorInputTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		367628851B4210520081488E /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		367628861B4210520081488E /* StringExtensionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 		367628881B4210520081488E /* MoneyCalculatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MoneyCalculatorTests.swift; sourceTree = "<group>"; };
@@ -132,7 +132,7 @@
 			isa = PBXGroup;
 			children = (
 				367628591B420FF80081488E /* CalculatorInput.framework */,
-				367628631B420FF80081488E /* CalculatorInput.xctest */,
+				367628631B420FF80081488E /* CalculatorInputTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -199,7 +199,7 @@
 			);
 			name = CalculatorInputTests;
 			productName = CalculatorInputViewTests;
-			productReference = 367628631B420FF80081488E /* CalculatorInput.xctest */;
+			productReference = 367628631B420FF80081488E /* CalculatorInputTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -216,6 +216,7 @@
 					};
 					367628621B420FF80081488E = {
 						CreatedOnToolsVersion = 7.0;
+						LastSwiftMigration = 0830;
 					};
 				};
 			};
@@ -421,7 +422,8 @@
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInputViewTests;
-				PRODUCT_NAME = CalculatorInput;
+				PRODUCT_NAME = CalculatorInputTests;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -431,7 +433,8 @@
 				INFOPLIST_FILE = Tests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.venmo.CalculatorInputViewTests;
-				PRODUCT_NAME = CalculatorInput;
+				PRODUCT_NAME = CalculatorInputTests;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/CalculatorInput.xcodeproj/xcshareddata/xcschemes/CalculatorInput-iOS.xcscheme
+++ b/CalculatorInput.xcodeproj/xcshareddata/xcschemes/CalculatorInput-iOS.xcscheme
@@ -23,17 +23,17 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "367628621B420FF80081488E"
-               BuildableName = "CalculatorInput.xctest"
+               BuildableName = "CalculatorInputTests.xctest"
                BlueprintName = "CalculatorInputTests"
                ReferencedContainer = "container:CalculatorInput.xcodeproj">
             </BuildableReference>
@@ -52,11 +52,11 @@
       </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       debugServiceExtension = "internal"
@@ -74,10 +74,10 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/CalculatorInput/CalculatorInputView.h
+++ b/CalculatorInput/CalculatorInputView.h
@@ -9,6 +9,7 @@
 
 @end
 
+IB_DESIGNABLE
 @interface CalculatorInputView : UIView <UIInputViewAudioFeedback>
 
 @property (weak, nonatomic) id<CalculatorInputViewDelegate> delegate;

--- a/CalculatorInput/CalculatorInputView.m
+++ b/CalculatorInput/CalculatorInputView.m
@@ -16,11 +16,13 @@
         // Set default locale
         self.locale = [NSLocale currentLocale];
 
+        [self setBackgroundColor:[UIColor colorWithRed:210/255.0f green:213/255.0f blue:219/255.0f alpha:1]];
+
         // Set customizable properties
         [self setNumberButtonBackgroundColor:[UIColor colorWithWhite:0.98828 alpha:1]];
-        [self setNumberButtonBorderColor:[UIColor colorWithRed:193/255.0f green:195/255.0f blue:199/255.0f alpha:1]];
-        [self setOperationButtonBackgroundColor:[UIColor colorWithRed:193/255.0f green:196/255.0f blue:200/255.0f alpha:1]];
-        [self setOperationButtonBorderColor:[UIColor colorWithRed:172/255.0f green:174/255.0f blue:177/255.0f alpha:1]];
+        [self setNumberButtonBorderColor:UIColor.clearColor];
+        [self setOperationButtonBackgroundColor:[UIColor colorWithRed:171/255.0f green:179/255.0f blue:190/255.0f alpha:1]];
+        [self setOperationButtonBorderColor:UIColor.clearColor];
         [self setButtonHighlightedColor:[UIColor grayColor]];
         [self setButtonTitleColor:[UIColor darkTextColor]];
 
@@ -43,6 +45,22 @@
 
 - (void)setupButton:(UIButton *)button {
     button.layer.borderWidth = 0.25f;
+    button.layer.cornerRadius = 5;
+    button.layer.shadowColor = [UIColor colorWithRed:136/255.0f green:139/255.0f blue:142/255.0f alpha:1].CGColor;
+    button.layer.shadowRadius = 0;
+    button.layer.shadowOpacity = 1.0f;
+    button.layer.shadowOffset = CGSizeMake(0, 1.0f);
+
+    [button addTarget:self action:@selector(buttonTouchDown:) forControlEvents:UIControlEventTouchDown];
+    [button addTarget:self action:@selector(buttonTouchUp:) forControlEvents:UIControlEventTouchUpInside];
+}
+
+- (void)buttonTouchDown:(UIButton *)button {
+    button.layer.masksToBounds = YES;
+}
+
+- (void)buttonTouchUp:(UIButton *)button {
+    button.layer.masksToBounds = NO;
 }
 
 - (IBAction)userDidTapBackspace:(UIButton *)sender {

--- a/CalculatorInput/Resources/CalculatorInputView.xib
+++ b/CalculatorInput/Resources/CalculatorInputView.xib
@@ -1,295 +1,272 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="8121.20" systemVersion="14D136" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="12121" systemVersion="16G29" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="8101.16"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="12089"/>
         <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner" customClass="CalculatorInputView"/>
         <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
         <view contentMode="scaleToFill" id="1" customClass="CalculatorInputView">
             <rect key="frame" x="0.0" y="0.0" width="320" height="216"/>
             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
             <subviews>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x27-vp-6DR">
-                    <rect key="frame" x="0.0" y="0.0" width="59" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Divide"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="÷">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="2lI-PU-xC5"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fUR-3U-wcK">
-                    <rect key="frame" x="59" y="0.0" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="One"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="1">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="wju-cY-KVJ"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JV6-sY-Ogr">
-                    <rect key="frame" x="59" y="54" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Four"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="4">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="vqD-gt-D5D"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jYZ-Lf-J5j">
-                    <rect key="frame" x="59" y="108" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Seven"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="7">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="YfT-3z-pVt"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eYd-gM-or0">
-                    <rect key="frame" x="59" y="162" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Decimal point"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title=".">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="QWQ-qv-HHB"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wf7-xV-pka">
-                    <rect key="frame" x="146" y="0.0" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Two"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="2">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="veB-xt-rnr"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BZC-sL-jHO">
-                    <rect key="frame" x="146" y="54" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Five"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="5">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="EyB-jX-8Ci"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="i9h-WF-taO">
-                    <rect key="frame" x="146" y="108" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Eight"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="8">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="W7z-SU-2Bb"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2Ty-om-JCT">
-                    <rect key="frame" x="146" y="162" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Zero"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="0">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="jh0-Bu-kbn"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="K9B-4z-Rq4">
-                    <rect key="frame" x="233" y="0.0" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Three"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="3">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="hHt-S1-qaK"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZMP-0C-Anz">
-                    <rect key="frame" x="233" y="54" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Six"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="6">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="2hq-ih-7qk"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vjs-Bi-wiF">
-                    <rect key="frame" x="233" y="162" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Backspace"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" image="VENCalculatorIconBackspace.png">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapBackspace:" destination="1" eventType="touchUpInside" id="Kyu-1V-QyI"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nS1-xf-Wd3">
-                    <rect key="frame" x="0.0" y="54" width="59" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Multiply"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="×">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="9jH-Sx-3A5"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xVG-Mb-OFf">
-                    <rect key="frame" x="0.0" y="108" width="59" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Subtract"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="−">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="Ri3-Vn-C6b"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WE3-xD-kgf">
-                    <rect key="frame" x="0.0" y="162" width="59" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Add"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="+">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="8B7-FJ-aLh"/>
-                    </connections>
-                </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJe-DO-RoA">
-                    <rect key="frame" x="233" y="108" width="87" height="54"/>
-                    <accessibility key="accessibilityConfiguration" label="Nine"/>
-                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="20"/>
-                    <state key="normal" title="9">
-                        <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
-                    </state>
-                    <connections>
-                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="nBV-ta-bQu"/>
-                    </connections>
-                </button>
+                <stackView opaque="NO" contentMode="scaleToFill" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="m5y-aX-zzD">
+                    <rect key="frame" x="6" y="6" width="308" height="204"/>
+                    <subviews>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="YG9-9C-9ZZ" userLabel="Digits">
+                            <rect key="frame" x="0.0" y="0.0" width="259" height="204"/>
+                            <subviews>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="xap-rN-gdp">
+                                    <rect key="frame" x="0.0" y="0.0" width="259" height="46.5"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fUR-3U-wcK">
+                                            <rect key="frame" x="0.0" y="0.0" width="82.5" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="One"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="1">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="wju-cY-KVJ"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Wf7-xV-pka">
+                                            <rect key="frame" x="88.5" y="0.0" width="82" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Two"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="2">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="veB-xt-rnr"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="K9B-4z-Rq4">
+                                            <rect key="frame" x="176.5" y="0.0" width="82.5" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Three"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="3">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="hHt-S1-qaK"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="RgB-1b-Sno">
+                                    <rect key="frame" x="0.0" y="52.5" width="259" height="46.5"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="JV6-sY-Ogr">
+                                            <rect key="frame" x="0.0" y="0.0" width="82.5" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Four"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="4">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="vqD-gt-D5D"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="BZC-sL-jHO">
+                                            <rect key="frame" x="88.5" y="0.0" width="82" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Five"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="5">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="EyB-jX-8Ci"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZMP-0C-Anz">
+                                            <rect key="frame" x="176.5" y="0.0" width="82.5" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Six"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="6">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="2hq-ih-7qk"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="ZlG-QT-rZB">
+                                    <rect key="frame" x="0.0" y="105" width="259" height="46.5"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="jYZ-Lf-J5j">
+                                            <rect key="frame" x="0.0" y="0.0" width="82.5" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Seven"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="7">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="YfT-3z-pVt"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="i9h-WF-taO">
+                                            <rect key="frame" x="88.5" y="0.0" width="82" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Eight"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="8">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="W7z-SU-2Bb"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WJe-DO-RoA">
+                                            <rect key="frame" x="176.5" y="0.0" width="82.5" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Nine"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="9">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="nBV-ta-bQu"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                                <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="I7x-Nf-lW1">
+                                    <rect key="frame" x="0.0" y="157.5" width="259" height="46.5"/>
+                                    <subviews>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="eYd-gM-or0">
+                                            <rect key="frame" x="0.0" y="0.0" width="82.5" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Decimal point"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title=".">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="QWQ-qv-HHB"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="2Ty-om-JCT">
+                                            <rect key="frame" x="88.5" y="0.0" width="82" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Zero"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" title="0">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="jh0-Bu-kbn"/>
+                                            </connections>
+                                        </button>
+                                        <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Vjs-Bi-wiF">
+                                            <rect key="frame" x="176.5" y="0.0" width="82.5" height="46.5"/>
+                                            <accessibility key="accessibilityConfiguration" label="Backspace"/>
+                                            <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                            <state key="normal" image="VENCalculatorIconBackspace.png">
+                                                <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                            </state>
+                                            <connections>
+                                                <action selector="userDidTapBackspace:" destination="1" eventType="touchUpInside" id="Kyu-1V-QyI"/>
+                                            </connections>
+                                        </button>
+                                    </subviews>
+                                </stackView>
+                            </subviews>
+                        </stackView>
+                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="fillEqually" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="Hoi-4x-VG1" userLabel="Operators">
+                            <rect key="frame" x="265" y="0.0" width="43" height="204"/>
+                            <subviews>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x27-vp-6DR">
+                                    <rect key="frame" x="0.0" y="0.0" width="43" height="46.5"/>
+                                    <accessibility key="accessibilityConfiguration" label="Divide"/>
+                                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                    <state key="normal" title="÷">
+                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="2lI-PU-xC5"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nS1-xf-Wd3">
+                                    <rect key="frame" x="0.0" y="52.5" width="43" height="46.5"/>
+                                    <accessibility key="accessibilityConfiguration" label="Multiply"/>
+                                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                    <state key="normal" title="×">
+                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="9jH-Sx-3A5"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="xVG-Mb-OFf">
+                                    <rect key="frame" x="0.0" y="105" width="43" height="46.5"/>
+                                    <accessibility key="accessibilityConfiguration" label="Subtract"/>
+                                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                    <state key="normal" title="−">
+                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="Ri3-Vn-C6b"/>
+                                    </connections>
+                                </button>
+                                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="WE3-xD-kgf">
+                                    <rect key="frame" x="0.0" y="157.5" width="43" height="46.5"/>
+                                    <accessibility key="accessibilityConfiguration" label="Add"/>
+                                    <fontDescription key="fontDescription" type="system" weight="light" pointSize="25"/>
+                                    <state key="normal" title="+">
+                                        <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                    </state>
+                                    <connections>
+                                        <action selector="userDidTapKey:" destination="1" eventType="touchUpInside" id="8B7-FJ-aLh"/>
+                                    </connections>
+                                </button>
+                            </subviews>
+                        </stackView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="Hoi-4x-VG1" firstAttribute="width" secondItem="YG9-9C-9ZZ" secondAttribute="width" multiplier="1:6" id="PJV-pH-fey"/>
+                    </constraints>
+                </stackView>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
-                <constraint firstItem="K9B-4z-Rq4" firstAttribute="top" secondItem="1" secondAttribute="top" id="0aG-0V-nbU"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="top" secondItem="1" secondAttribute="top" id="0hI-dQ-Yua"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="leading" secondItem="1" secondAttribute="leading" id="1zq-D3-xri"/>
-                <constraint firstAttribute="bottom" secondItem="WE3-xD-kgf" secondAttribute="bottom" id="4W6-NC-MI4"/>
-                <constraint firstItem="eYd-gM-or0" firstAttribute="leading" secondItem="WE3-xD-kgf" secondAttribute="trailing" id="5GF-vF-W6i"/>
-                <constraint firstAttribute="trailing" secondItem="ZMP-0C-Anz" secondAttribute="trailing" id="5b6-5X-KBE"/>
-                <constraint firstItem="i9h-WF-taO" firstAttribute="top" secondItem="BZC-sL-jHO" secondAttribute="bottom" id="6WH-Ic-Q7R"/>
-                <constraint firstItem="2Ty-om-JCT" firstAttribute="leading" secondItem="eYd-gM-or0" secondAttribute="trailing" id="6lk-So-fYf"/>
-                <constraint firstItem="jYZ-Lf-J5j" firstAttribute="top" secondItem="JV6-sY-Ogr" secondAttribute="bottom" id="6xI-Uj-apO"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="width" secondItem="nS1-xf-Wd3" secondAttribute="width" id="7Xi-5G-Zqo"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="JV6-sY-Ogr" secondAttribute="height" id="8g3-SF-naV"/>
-                <constraint firstAttribute="trailing" secondItem="Vjs-Bi-wiF" secondAttribute="trailing" id="8n2-Dg-KJi"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="Vjs-Bi-wiF" secondAttribute="width" id="9AY-LQ-tGg"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="K9B-4z-Rq4" secondAttribute="width" id="9If-Xo-3ix"/>
-                <constraint firstItem="2Ty-om-JCT" firstAttribute="leading" secondItem="eYd-gM-or0" secondAttribute="trailing" id="9ec-Bt-vl8"/>
-                <constraint firstItem="Vjs-Bi-wiF" firstAttribute="leading" secondItem="2Ty-om-JCT" secondAttribute="trailing" id="ALr-CX-0Az"/>
-                <constraint firstAttribute="trailing" secondItem="K9B-4z-Rq4" secondAttribute="trailing" id="BXC-SX-Rrl"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="height" secondItem="fUR-3U-wcK" secondAttribute="height" id="CfP-bt-Y6n"/>
-                <constraint firstItem="fUR-3U-wcK" firstAttribute="leading" secondItem="x27-vp-6DR" secondAttribute="trailing" id="Dpo-eO-8X0"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="leading" secondItem="xVG-Mb-OFf" secondAttribute="leading" id="ESa-sQ-b88"/>
-                <constraint firstAttribute="trailing" secondItem="WJe-DO-RoA" secondAttribute="trailing" id="FOV-yZ-4d3"/>
-                <constraint firstItem="2Ty-om-JCT" firstAttribute="leading" secondItem="eYd-gM-or0" secondAttribute="trailing" id="Ggv-ks-9iv"/>
-                <constraint firstItem="ZMP-0C-Anz" firstAttribute="top" secondItem="K9B-4z-Rq4" secondAttribute="bottom" id="HWK-YB-3fu"/>
-                <constraint firstItem="BZC-sL-jHO" firstAttribute="top" secondItem="Wf7-xV-pka" secondAttribute="bottom" id="Hha-vG-YFP"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="2Ty-om-JCT" secondAttribute="height" id="I9y-eA-Otl"/>
-                <constraint firstItem="nS1-xf-Wd3" firstAttribute="top" secondItem="x27-vp-6DR" secondAttribute="bottom" id="IIR-HS-nd3"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="JV6-sY-Ogr" secondAttribute="width" id="IUJ-GH-5GI"/>
-                <constraint firstItem="xVG-Mb-OFf" firstAttribute="top" secondItem="nS1-xf-Wd3" secondAttribute="bottom" id="Mgu-AQ-9cI"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="BZC-sL-jHO" secondAttribute="width" id="Mph-8n-3UC"/>
-                <constraint firstItem="2Ty-om-JCT" firstAttribute="leading" secondItem="eYd-gM-or0" secondAttribute="trailing" id="NEt-mT-r3w"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="Wf7-xV-pka" secondAttribute="width" id="OdY-Nu-n2d"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="ZMP-0C-Anz" secondAttribute="height" id="Qcj-xV-qXn"/>
-                <constraint firstItem="xVG-Mb-OFf" firstAttribute="top" secondItem="nS1-xf-Wd3" secondAttribute="bottom" id="Shh-HK-B2r"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="top" secondItem="ZMP-0C-Anz" secondAttribute="bottom" id="VfG-Tv-PG1"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="width" secondItem="fUR-3U-wcK" secondAttribute="width" multiplier="59:87" id="WNW-Wv-PhX"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="fUR-3U-wcK" secondAttribute="width" id="Y9T-Rf-Eth"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="eYd-gM-or0" secondAttribute="width" id="YCa-dD-nKM"/>
-                <constraint firstItem="Vjs-Bi-wiF" firstAttribute="top" secondItem="WJe-DO-RoA" secondAttribute="bottom" id="Zrm-BE-092"/>
-                <constraint firstItem="jYZ-Lf-J5j" firstAttribute="leading" secondItem="xVG-Mb-OFf" secondAttribute="trailing" id="aLB-4k-asu"/>
-                <constraint firstItem="JV6-sY-Ogr" firstAttribute="leading" secondItem="nS1-xf-Wd3" secondAttribute="trailing" id="b7p-nW-Iup"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="Wf7-xV-pka" secondAttribute="height" id="cV1-9K-qh1"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="leading" secondItem="nS1-xf-Wd3" secondAttribute="leading" id="d8u-0Z-HCZ"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="leading" secondItem="WE3-xD-kgf" secondAttribute="leading" id="dNa-Se-4De"/>
-                <constraint firstItem="fUR-3U-wcK" firstAttribute="top" secondItem="1" secondAttribute="top" id="eC6-zq-5wM"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="ZMP-0C-Anz" secondAttribute="width" id="eEE-7C-Kpa"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="i9h-WF-taO" secondAttribute="width" id="eMq-4H-6ox"/>
-                <constraint firstItem="2Ty-om-JCT" firstAttribute="leading" secondItem="eYd-gM-or0" secondAttribute="trailing" id="eWf-He-GIQ"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="jYZ-Lf-J5j" secondAttribute="width" id="fJX-BW-jA3"/>
-                <constraint firstItem="2Ty-om-JCT" firstAttribute="top" secondItem="i9h-WF-taO" secondAttribute="bottom" id="gMi-xC-yDo"/>
-                <constraint firstItem="Wf7-xV-pka" firstAttribute="leading" secondItem="fUR-3U-wcK" secondAttribute="trailing" id="gax-7O-o2i"/>
-                <constraint firstAttribute="bottom" secondItem="eYd-gM-or0" secondAttribute="bottom" id="hEo-eE-Pay"/>
-                <constraint firstAttribute="bottom" secondItem="2Ty-om-JCT" secondAttribute="bottom" id="hJ7-C8-W0y"/>
-                <constraint firstItem="BZC-sL-jHO" firstAttribute="leading" secondItem="JV6-sY-Ogr" secondAttribute="trailing" id="jOS-cf-9Rn"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="eYd-gM-or0" secondAttribute="height" id="kM7-G0-PcB"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="fUR-3U-wcK" secondAttribute="height" id="ka8-cg-Zcx"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="i9h-WF-taO" secondAttribute="height" id="mFK-TV-7Ot"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="K9B-4z-Rq4" secondAttribute="height" id="nqe-l2-G0n"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="width" secondItem="xVG-Mb-OFf" secondAttribute="width" id="ol4-0o-R3o"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="BZC-sL-jHO" secondAttribute="height" id="pbk-Gp-ina"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="height" secondItem="nS1-xf-Wd3" secondAttribute="height" id="qDm-bK-5jf"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="width" secondItem="2Ty-om-JCT" secondAttribute="width" id="qag-rr-rch"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="width" secondItem="WE3-xD-kgf" secondAttribute="width" id="qdb-Id-iDJ"/>
-                <constraint firstItem="jYZ-Lf-J5j" firstAttribute="height" secondItem="xVG-Mb-OFf" secondAttribute="height" id="qo1-cu-0tr"/>
-                <constraint firstItem="WE3-xD-kgf" firstAttribute="height" secondItem="eYd-gM-or0" secondAttribute="height" id="rJr-34-wA6"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="Vjs-Bi-wiF" secondAttribute="height" id="rW3-FG-nhP"/>
-                <constraint firstItem="Wf7-xV-pka" firstAttribute="top" secondItem="1" secondAttribute="top" id="rYD-zE-9Z9"/>
-                <constraint firstItem="x27-vp-6DR" firstAttribute="height" secondItem="fUR-3U-wcK" secondAttribute="height" id="sOJ-2h-b0k"/>
-                <constraint firstItem="fUR-3U-wcK" firstAttribute="leading" secondItem="x27-vp-6DR" secondAttribute="trailing" id="sn4-v7-sRs"/>
-                <constraint firstItem="Vjs-Bi-wiF" firstAttribute="top" secondItem="WJe-DO-RoA" secondAttribute="bottom" id="ulr-bm-xDL"/>
-                <constraint firstItem="xVG-Mb-OFf" firstAttribute="top" secondItem="nS1-xf-Wd3" secondAttribute="bottom" id="wXS-eT-5vV"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="leading" secondItem="i9h-WF-taO" secondAttribute="trailing" id="wbX-JW-2aa"/>
-                <constraint firstItem="nS1-xf-Wd3" firstAttribute="height" secondItem="fUR-3U-wcK" secondAttribute="height" id="xIF-8w-F7x"/>
-                <constraint firstItem="WJe-DO-RoA" firstAttribute="height" secondItem="jYZ-Lf-J5j" secondAttribute="height" id="xN4-z0-CMv"/>
-                <constraint firstItem="JV6-sY-Ogr" firstAttribute="top" secondItem="fUR-3U-wcK" secondAttribute="bottom" id="yIQ-wk-MLa"/>
-                <constraint firstItem="Vjs-Bi-wiF" firstAttribute="top" secondItem="WJe-DO-RoA" secondAttribute="bottom" id="z58-MV-3gM"/>
+                <constraint firstItem="m5y-aX-zzD" firstAttribute="leading" secondItem="1" secondAttribute="leading" constant="6" id="JIq-vf-SGQ"/>
+                <constraint firstAttribute="bottom" secondItem="m5y-aX-zzD" secondAttribute="bottom" constant="6" id="WK5-Tz-IZK"/>
+                <constraint firstItem="m5y-aX-zzD" firstAttribute="top" secondItem="1" secondAttribute="top" constant="6" id="iVW-Zg-B1b"/>
+                <constraint firstAttribute="trailing" secondItem="m5y-aX-zzD" secondAttribute="trailing" constant="6" id="k4y-tu-XDx"/>
             </constraints>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
                 <outlet property="decimalButton" destination="eYd-gM-or0" id="Lng-xU-k41"/>
-                <outletCollection property="numberButtonCollection" destination="2Ty-om-JCT" id="YQr-Vb-a62"/>
-                <outletCollection property="operationButtonCollection" destination="WE3-xD-kgf" id="m1z-hQ-z5E"/>
-                <outletCollection property="numberButtonCollection" destination="i9h-WF-taO" id="kgO-g8-e3f"/>
                 <outletCollection property="numberButtonCollection" destination="fUR-3U-wcK" id="Gdv-We-GU2"/>
+                <outletCollection property="numberButtonCollection" destination="WJe-DO-RoA" id="8H0-Ov-SWV"/>
                 <outletCollection property="numberButtonCollection" destination="Wf7-xV-pka" id="Ecs-7q-nGm"/>
-                <outletCollection property="numberButtonCollection" destination="K9B-4z-Rq4" id="KIn-1C-Dcl"/>
-                <outletCollection property="numberButtonCollection" destination="JV6-sY-Ogr" id="ydT-nj-xlx"/>
-                <outletCollection property="numberButtonCollection" destination="BZC-sL-jHO" id="aqd-rn-Loj"/>
                 <outletCollection property="numberButtonCollection" destination="ZMP-0C-Anz" id="VZF-LY-S9Z"/>
                 <outletCollection property="numberButtonCollection" destination="jYZ-Lf-J5j" id="mva-Hj-hfI"/>
-                <outletCollection property="numberButtonCollection" destination="WJe-DO-RoA" id="8H0-Ov-SWV"/>
-                <outletCollection property="operationButtonCollection" destination="x27-vp-6DR" id="UQW-WX-jyQ"/>
-                <outletCollection property="operationButtonCollection" destination="nS1-xf-Wd3" id="Cyu-bs-cdg"/>
-                <outletCollection property="operationButtonCollection" destination="xVG-Mb-OFf" id="vMh-VD-5cC"/>
+                <outletCollection property="numberButtonCollection" destination="BZC-sL-jHO" id="aqd-rn-Loj"/>
+                <outletCollection property="numberButtonCollection" destination="K9B-4z-Rq4" id="KIn-1C-Dcl"/>
                 <outletCollection property="operationButtonCollection" destination="eYd-gM-or0" id="Pcu-vP-N1v"/>
+                <outletCollection property="numberButtonCollection" destination="JV6-sY-Ogr" id="ydT-nj-xlx"/>
                 <outletCollection property="operationButtonCollection" destination="Vjs-Bi-wiF" id="Ali-RS-13G"/>
+                <outletCollection property="numberButtonCollection" destination="i9h-WF-taO" id="kgO-g8-e3f"/>
+                <outletCollection property="numberButtonCollection" destination="2Ty-om-JCT" id="YQr-Vb-a62"/>
+                <outletCollection property="operationButtonCollection" destination="x27-vp-6DR" id="UQW-WX-jyQ"/>
+                <outletCollection property="operationButtonCollection" destination="xVG-Mb-OFf" id="vMh-VD-5cC"/>
+                <outletCollection property="operationButtonCollection" destination="nS1-xf-Wd3" id="Cyu-bs-cdg"/>
+                <outletCollection property="operationButtonCollection" destination="WE3-xD-kgf" id="m1z-hQ-z5E"/>
             </connections>
+            <point key="canvasLocation" x="72" y="77"/>
         </view>
     </objects>
     <resources>
-        <image name="VENCalculatorIconBackspace.png" width="25" height="26"/>
+        <image name="VENCalculatorIconBackspace.png" width="22" height="16"/>
     </resources>
+    <simulatedMetricsContainer key="defaultSimulatedMetrics">
+        <simulatedStatusBarMetrics key="statusBar"/>
+        <simulatedOrientationMetrics key="orientation"/>
+        <simulatedScreenMetrics key="destination" type="retina4_7.fullscreen"/>
+    </simulatedMetricsContainer>
 </document>

--- a/Tests/MoneyCalculatorTests.swift
+++ b/Tests/MoneyCalculatorTests.swift
@@ -5,7 +5,7 @@ import CalculatorInput
 class MoneyCalculatorTests: XCTestCase {
     let calculator: MoneyCalculator = {
         let calc = MoneyCalculator()
-        calc.locale = NSLocale(localeIdentifier: "en_US")
+        calc.locale = Locale(identifier: "en_US")
         return calc
     }()
 
@@ -70,7 +70,7 @@ class MoneyCalculatorTests: XCTestCase {
 class MoneyCalculatorFrenchTests: XCTestCase {
     let calculator: MoneyCalculator = {
         let calc = MoneyCalculator()
-        calc.locale = NSLocale(localeIdentifier: "fr_FR")
+        calc.locale = Locale(identifier: "fr_FR")
         return calc
     }()
 
@@ -88,7 +88,7 @@ class MoneyCalculatorFrenchTests: XCTestCase {
 class MoneyCalculatorGermanTests: XCTestCase {
     let calculator: MoneyCalculator = {
         let calc = MoneyCalculator()
-        calc.locale = NSLocale(localeIdentifier: "de_DE")
+        calc.locale = Locale(identifier: "de_DE")
         return calc
     }()
 
@@ -111,7 +111,7 @@ class MoneyCalculatorGermanTests: XCTestCase {
 class MoneyCalculatorVietnameTests: XCTestCase {
     func testVietnamese() {
         let calculator = MoneyCalculator()
-        calculator.locale = NSLocale(localeIdentifier: "vi_VN")
+        calculator.locale = Locale(identifier: "vi_VN")
         XCTAssertEqual("2", calculator.evaluateExpression("1,90")!)
         XCTAssertEqual("1", calculator.evaluateExpression("1,30")!)
         XCTAssertEqual("1", calculator.evaluateExpression("0,90")!)
@@ -119,7 +119,7 @@ class MoneyCalculatorVietnameTests: XCTestCase {
 
     func testUS() {
         let calculator = MoneyCalculator()
-        calculator.locale = NSLocale(localeIdentifier: "en_US")
+        calculator.locale = Locale(identifier: "en_US")
         XCTAssertEqual("1.90", calculator.evaluateExpression("1.90")!)
         XCTAssertEqual("1.30", calculator.evaluateExpression("1.30")!)
         XCTAssertEqual("0.90", calculator.evaluateExpression("0.90")!)

--- a/Tests/StringExtensionTests.swift
+++ b/Tests/StringExtensionTests.swift
@@ -4,13 +4,13 @@ import CalculatorInput
 
 class StringExtensionTests: XCTestCase {
     func testWhitespace() {
-        let result = NSString(string: "foo     bar\n           ").ven_stringByReplacingCharactersInSet(NSCharacterSet.whitespaceAndNewlineCharacterSet(), withString: "")
+        let result = NSString(string: "foo     bar\n           ").ven_stringByReplacingCharacters(in: CharacterSet.whitespacesAndNewlines, with: "")
         XCTAssertEqual("foobar", result)
     }
 
     func testCustomCharacterSet() {
-        let characterSet = NSCharacterSet(charactersInString: "0123456789-/*.+").invertedSet
-        let result = NSString(string: "1+1(&^!@#+1foobar").ven_stringByReplacingCharactersInSet(characterSet, withString: "")
+        let characterSet = CharacterSet(charactersIn: "0123456789-/*.+").inverted
+        let result = NSString(string: "1+1(&^!@#+1foobar").ven_stringByReplacingCharacters(in: characterSet, with: "")
         XCTAssertEqual("1+1+1", result)
     }
 }


### PR DESCRIPTION
In order to match the design of most calculators, the operator keys
were moved to the right-hand side. This will hopefully improve
discoverability of the operators for users. In addition, the look of the
buttons were updated to have a corner radius and the buttons are spaced
out.

The Nib file now uses Stack Views, and as such the deployment target for
the project was set to 9.0.

Some other changes:

* The CalculatorInputView.xib File Owner is now CalculatorInputView and
  it is marked as IB_DESIGNABLE.
* The buttons now have a slight drop shadow
* The size of the text on the buttons was increased 25%

Lastly, in order to hide the drop shadow on touch down and maintain the
corner radius, the `maskToBounds` property is toggled in action methods.

![image](https://user-images.githubusercontent.com/38792/30182574-485fd872-93e5-11e7-9b15-f21b96851ef6.png)
